### PR TITLE
drop support for Docker Toolbox

### DIFF
--- a/templates/dotfiles/.env
+++ b/templates/dotfiles/.env
@@ -1,7 +1,7 @@
 # https://github.com/ddollar/forego
 APPLICATION_HOST=localhost:3000
 ASSET_HOST=localhost:3000
-DB_HOST=192.168.99.100
+DB_HOST=localhost
 DB_USER=postgres
 EXECJS_RUNTIME=Node
 PORT=3000


### PR DESCRIPTION
Docker for Mac doesn’t need `docker-machine` anymore
